### PR TITLE
Fix declaration of the ArgsFlags concept.

### DIFF
--- a/src/OptProcessor.cc
+++ b/src/OptProcessor.cc
@@ -30,9 +30,8 @@ auto getTypeCk(const toml::table& tbl, std::string_view key) {
   exitWithErr("Incorrect TOML type for {}", key);
 #pragma GCC diagnostic pop
 }
-template<typename T> concept ArgsFlag = requires(T flg) {
-  std::derived_from<T, args::FlagBase>;
-};
+template<typename T> concept ArgsFlag = std::derived_from<T, args::FlagBase>;
+
 template<typename T, ArgsFlag F>
 auto getOrDefault(F& flg, const toml::table& tbl, std::string_view key, T&& defaultVal) {
   if(flg) return flg.Get();


### PR DESCRIPTION
The syntax used so far triggers a compiler warning for me:
```
/home/bangerth/tmp/g/modularizer/importizer/src/OptProcessor.cc:34:3: warning: testing if a concept-id is a valid expression; add ‘requires’ to check satisfaction [-Wmissing-requires]
   34 |   std::derived_from<T, args::FlagBase>;
      |   ^
      |   requires 
```
This is because the syntax
```
requires (T flags) {
  std::derived_from<T, args::FlagBase>;
};
```
only checks that the enclosed expression `std::derived_from<T, args::FlagBase>` is *valid*, not that it is `true`. This patch fixes it to what I assume was originally intended.